### PR TITLE
update default boss-templates repository

### DIFF
--- a/boss/cli/bootstrap.py
+++ b/boss/cli/bootstrap.py
@@ -14,7 +14,7 @@ def setup_db(app):
         sources = app.db['sources']
         sources['boss'] = dict(
             label='boss',
-            path='https://github.com/derks/boss-templates.git',
+            path='https://github.com/datafolklabs/boss-templates.git',
             cache=cache_dir,
             is_local=False,
             last_sync_time='never'


### PR DESCRIPTION
Hi,
would you mind merging this?
The current reference seems outdated and the documentation (doc/source/dev/quickstart.rst) already refers to your new repository.
Cheers,
Mathias