### PR TITLE
fix for external files in python3

### DIFF
--- a/boss/cli/template.py
+++ b/boss/cli/template.py
@@ -271,7 +271,7 @@ class TemplateManager(object):
                 dest_path = self._sub(os.path.join(dest_basedir, _file))
                 remote_uri = self._sub(remote_uri)
                 try:
-                    data = self._sub(urlopen(remote_uri).read())
+                    data = self._sub(urlopen(remote_uri).read().decode('utf8'))
                 except HTTPError as e:
                     data = ''
 


### PR DESCRIPTION
External files was handled as binary blob but not like string
[](https://github.com/datafolklabs/boss/issues/27) #27 